### PR TITLE
path version 사용

### DIFF
--- a/function.weather.js
+++ b/function.weather.js
@@ -120,12 +120,14 @@ class Weather {
         let urls =[];
         let domainUrl;
         let ipUrl;
+        let version = event.pathParameters.version || this.version;
+
         if (serviceServerIp) {
-            ipUrl = this._geoinfo2url(serviceServerIp, this.version, geoInfo);
+            ipUrl = this._geoinfo2url(serviceServerIp, version, geoInfo);
             ipUrl = this._appendQueryParameters(ipUrl, event);
             urls.push(ipUrl);
         }
-        domainUrl = this._geoinfo2url(this.url, this.version, geoInfo);
+        domainUrl = this._geoinfo2url(this.url, version, geoInfo);
         domainUrl = this._appendQueryParameters(domainUrl, event);
         urls.push(domainUrl);
         return urls;

--- a/function.weather.js
+++ b/function.weather.js
@@ -120,7 +120,14 @@ class Weather {
         let urls =[];
         let domainUrl;
         let ipUrl;
-        let version = event.pathParameters.version || this.version;
+        let version;
+
+        if (event && event.pathParameters) {
+            version = event.pathParameters.version || this.version;
+        }
+        else {
+            version = this.version;
+        }
 
         if (serviceServerIp) {
             ipUrl = this._geoinfo2url(serviceServerIp, version, geoInfo);

--- a/serverless.yml
+++ b/serverless.yml
@@ -13,9 +13,9 @@
 
 service: tw-backend-functions
 
-#plugins:
-#  - serverless-dynamodb-local
-#  - serverless-offline
+plugins:
+  - serverless-dynamodb-local
+  - serverless-offline
 
 custom:
   dynamoGeoCodeDBTableName: "${opt:stage, self:provider.stage}-geocode"
@@ -116,6 +116,10 @@ functions:
     events:
       - http:
           path: weather/coord/{loc}
+          method: get
+          cors: true
+      - http:
+          path: weather/{version}/coord/{loc}
           method: get
           cors: true
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -13,9 +13,9 @@
 
 service: tw-backend-functions
 
-plugins:
-  - serverless-dynamodb-local
-  - serverless-offline
+#plugins:
+#  - serverless-dynamodb-local
+#  - serverless-offline
 
 custom:
   dynamoGeoCodeDBTableName: "${opt:stage, self:provider.stage}-geocode"


### PR DESCRIPTION
#1895
version들어간 path 추가
aws api gateway에서는 weather/coord/{loc}와
weather/coord/{version}/{loc}를 같이 사용 못함
cloudfront에서 weather/* 로 전달하기 때문에
weather/{version}/coord/{loc} 로 형태로 version추가 함

https://github.com/WizardFactory/TodayWeather/issues/1895
